### PR TITLE
Added support for multiple tags on a single commit

### DIFF
--- a/tasks/ExtractVersionFromTagTask/extract-version-from-tag.ts
+++ b/tasks/ExtractVersionFromTagTask/extract-version-from-tag.ts
@@ -11,6 +11,7 @@ const NUMBER_OF_COMMITS_SINCE_TAG: string = 'NUMBER_OF_COMMITS_SINCE_TAG';
 async function run() {
     try {
         var projectFolderPath = task.getPathInput('projectFolderPath');
+        var hasMultipleTags = task.getPathInput('hasMultipleTags');
 
         if (!fs.existsSync(projectFolderPath)) {
             task.error(`Source directory does not exist: ${projectFolderPath}`);
@@ -22,6 +23,8 @@ async function run() {
 
         let git: string = task.which('git', true);
         var args = ["describe", "--tags", "--abbrev=0"];
+        if (hasMultipleTags === true)
+            args = ["tag", "-l", "'v*'"];
 
         let tagResult = task.execSync(git, args);
 


### PR DESCRIPTION
Added support for multiple tags on a single commit. It will search for all tags starting with v and get the first one only.

@damienaicheh I created this PR to add support for multiple tags in a commit, so it gets the tag starting with "v".

Please review and let me know what you think about it.

This is just my grain of salt to contribute with this awesome task for Azure Pipelines.